### PR TITLE
Duplicate assets in scale folders

### DIFF
--- a/lib/ci/ci_assets.dart
+++ b/lib/ci/ci_assets.dart
@@ -57,9 +57,16 @@ String buildAssetList(List<File> files, [Directory? relative]) {
   final buffer = StringBuffer();
   final offset = (relative?.path.length ?? -1) + 1;
 
-  files.forEach((element) {
-    buffer.writeln('  final ${element.name} = \'${element.relativePath(offset)}\';');
-  });
+  final nameSet = <String>{};
+  for (final element in files) {
+    {
+      if(nameSet.contains(element.name)){
+        continue;
+      }
+      buffer.writeln('  final ${element.name} = \'${element.relativePath(offset)}\';');
+      nameSet.add(element.name);
+    }
+  }
 
   return buffer.toString();
 }


### PR DESCRIPTION
This change will not write file variable in Res file if it was already written. There will still be issue, that only highest res image will be written down, since generator goes to 3.0x folder last. But it will fix duplicate variables in generated file. Proper generating strategy might be implemented furthermore.